### PR TITLE
Cachebust feature

### DIFF
--- a/lib/dart_to_js_script_rewriter.dart
+++ b/lib/dart_to_js_script_rewriter.dart
@@ -12,9 +12,16 @@ import 'package:html/parser.dart' show parse;
 /// speeds up initial loads. Win!
 class DartToJsScriptRewriter extends Transformer {
   bool releaseMode = false;
+  bool cacheBust = false;
+  String cacheBustKey = "dartcachebust";
 
-  DartToJsScriptRewriter.asPlugin(BarbackSettings settings)
-      : releaseMode = (settings.mode == BarbackMode.RELEASE);
+  DartToJsScriptRewriter.asPlugin(BarbackSettings settings){
+    releaseMode = (settings.mode == BarbackMode.RELEASE);
+    cacheBust = (settings.configuration.containsKey("bust_cache") && settings.configuration["bust_cache"] == true);
+    if(settings.configuration.containsKey("bust_cache_key")){
+      cacheBustKey = settings.configuration["bust_cache_key"];
+    }
+  }
 
   String get allowedExtensions => ".html";
 
@@ -48,16 +55,26 @@ class DartToJsScriptRewriter extends Transformer {
     }).forEach((tag) {
       var src = tag.attributes['src'];
       var query = "";
+      var cacheBustString = "${new DateTime.now().millisecondsSinceEpoch.toString()}";
       if(src.contains("?")){
         var spliturl = src.split("?");
         src = spliturl[0];
         query = spliturl[1];
       }
+
       if(query.length > 0){
-        tag.attributes['src'] = '${src}.js?${query}';
+        src = '${src}.js?${query}';
+        if(cacheBust){
+          src = "${src}&${cacheBustKey}=${cacheBustString}";
+        }
       }else{
-        tag.attributes['src'] = '${src}.js';
+        src = '${src}.js';
+        if(cacheBust){
+          src = "${src}?${cacheBustKey}=${cacheBustString}";
+        }
       }
+
+      tag.attributes['src'] = src;
       tag.attributes.remove('type');
     });
   }

--- a/lib/dart_to_js_script_rewriter.dart
+++ b/lib/dart_to_js_script_rewriter.dart
@@ -47,7 +47,17 @@ class DartToJsScriptRewriter extends Transformer {
           tag.attributes['src'] != null;
     }).forEach((tag) {
       var src = tag.attributes['src'];
-      tag.attributes['src'] = '${src}.js';
+      var query = "";
+      if(src.contains("?")){
+        var spliturl = src.split("?");
+        src = spliturl[0];
+        query = spliturl[1];
+      }
+      if(query.length > 0){
+        tag.attributes['src'] = '${src}.js?${query}';
+      }else{
+        tag.attributes['src'] = '${src}.js';
+      }
       tag.attributes.remove('type');
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,4 +12,6 @@ dev_dependencies:
   browser: any
   test: any
 transformers:
-- dart_to_js_script_rewriter
+- dart_to_js_script_rewriter:
+    bust_cache: true
+    bust_cache_key: "dartcache"


### PR DESCRIPTION
Related (and dependent) to my previous pull request, but this enables auto cache busting by passing in

```
bust_cache: true
bust_cache_key: "dartcache"
```

into the transformer arguments in pubspec.yaml.

bust_cache_key is optional.
