### PR TITLE
CP-1320 Release dart_to_js_script_rewriter 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ author:
   - Jay Udey <jay.udey@workiva.com>
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
-version: 0.1.0+4
+version: 1.0.0
 homepage: https://github.com/Workiva/dart_to_js_script_rewriter
 environment:
   sdk: ">=1.12.0 <2.0.0"


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1320

JIRA and PR's included in this release: 


 CP-1328  - Move dart_to_js_script_rewriter to workiva ownership  - https://github.com/Workiva/dart_to_js_script_rewriter/pull/28
 CP-1336  - kasperpeulen: make sure that transformer only touches file that need to be rewritten  - https://github.com/Workiva/dart_to_js_script_rewriter/pull/29
 CP-1355  - Create COPYRIGHT_TRANSFER  - https://github.com/Workiva/dart_to_js_script_rewriter/pull/31

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_to_js_Script_rewriter/compare/master...CP-1320_release_1.0.0