### PR TITLE
CP-1395 Correct pub publish updates

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_to_js_script_rewriter
 description: Replaces Dart script tags with JavaScript script tags,
              speeding up initial loads and reducing 404s. Use when
              ready to deploy.
-author:
+authors:
   - Seth Ladd <sethladd@gmail.com>
   - Workiva Client Platform Team <clientplatform@workiva.com>
   - Dustin Lessard <dustin.lessard@workiva.com>


### PR DESCRIPTION
## Issue
- I wasn't able to publish to pub because the pubspec.yaml had an in-correct field

## Changes
**Source:**
- referenced authors instead of author

**Tests:**
- n/a

## Areas of Regression
- n/a

## Testing
- verify `pub publish --dry-run` results in no warnings

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf