### PR TITLE
CP-1394 Release dart_to_js_script_rewriter 1.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Jay Udey <jay.udey@workiva.com>
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/Workiva/dart_to_js_script_rewriter
 environment:
   sdk: ">=1.12.0 <2.0.0"


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1394

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



 CP-1395  - Correct pub publish updates  - https://github.com/Workiva/dart_to_js_script_rewriter/pull/33

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_to_js_script_rewriter/compare/1.0.0...CP-1394_release_1.0.1

