### PR TITLE
CP-2938 Adding smithy.yaml

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,12 @@
+project: dart
+language: dart
+
+# dart 1.19.1
+runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+
+script:
+  - pub get
+
+artifacts:
+  build:
+    - ./pubspec.lock


### PR DESCRIPTION
## Issue
- We needed to add a smithy.yaml for release management to more easily track dependencies.

## Changes
**Source:**
- Included smithy.yaml

**Tests:**
- n/a

## Areas of Regression
- passing CI's

## Testing
- passing CI

## Code Review
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf
@sebastianmalysa-wf 