### PR TITLE
WP-4017 Add a docs.yml

### DIFF
--- a/docs.yml
+++ b/docs.yml
@@ -1,0 +1,3 @@
+title: dart_to_js_script_rewriter
+base: github:Workiva/dart_to_js_script_rewriter/
+src: README.md


### PR DESCRIPTION
We need a `docs.yml` file so that this lib's README can be displayed in the dev portal.