### PR TITLE
Release dart_to_js_script_rewriter 1.0.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Jay Udey <jay.udey@workiva.com>
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/Workiva/dart_to_js_script_rewriter
 environment:
   sdk: ">=1.12.0 <2.0.0"


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4017 Add a docs.yml](https://github.com/Workiva/dart_to_js_script_rewriter/pull/42)
* [HY-4965 Turn on strong mode and 2 lint rules](https://github.com/Workiva/dart_to_js_script_rewriter/pull/44)
* [CP-2938 Adding smithy.yaml](https://github.com/Workiva/dart_to_js_script_rewriter/pull/38)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_to_js_script_rewriter/compare/1.0.2...version-bump-dart_to_js_script_rewriter-1-0-3_1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_to_js_script_rewriter/compare/1.0.2...1.0.3